### PR TITLE
Locked menus and open in selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Extension.create({
 
 A menu elements can either be a simple `CommandItem` that executes an action, or it can be a `SubMenu` that can be opened to show its elements. 
 You can nest submenus into other submenus as needed. 
+The `locked` property can be used to hide a menu element from the user. The main idea behind it is to have a `SubMenu` that can only be opened by sending a transaction with `openSubMenu` meta. 
+Once opened it behaves like a second, hidden slash menu. For eg. you can have a command that needs approval or rejection after execution, you could open the slash menu with just these two options that are otherwise hidden.
 
 NOTE: It is necessary to add unique ids to every menu element. 
 ```typescript
@@ -62,12 +64,13 @@ type MenuItem = {
   id: ItemId;
   label: string;
   type: ItemType;
+  available: () => boolean;
+  locked?: boolean;
 };
 
 interface CommandItem extends MenuItem {
  type: "command";
  command: (view: EditorView) => void;
- available: () => boolean;
 }
 
 interface SubMenu extends MenuItem {

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ interface OpeningConditions {
   ) => boolean;
 }
 ```
+### Open in selection 
+
+You have the option to open the menu even if you have something selected. 
+
+`openInSelection: boolean` 
 
 # Behaviour
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.11",
         "nodemon": "^2.0.22",
-        "np": "^8.0.4",
+        "np": "^8.0.2",
         "npm-check": "^6.0.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.8",
@@ -33,6 +33,10 @@
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-typescript2": "^0.34.1",
         "typescript": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,12 +1,16 @@
 import {
   findParent,
   getElementById,
-  getFilteredItems,
   getNextItemId,
   getPreviousItemId,
 } from "./utils";
-import { SlashMenuMeta, SlashMenuState } from "./types";
-
+import { SlashMenuMeta, SlashMenuState, SubMenu } from "./types";
+export const closeMenu = (initialState: SlashMenuState) => {
+  console.log("closingMenu");
+  const callback = initialState.callbackOnClose;
+  callback && callback();
+  return initialState;
+};
 export const openSubMenu = (state: SlashMenuState, meta: SlashMenuMeta) => {
   const menuElement = meta.element;
   if (menuElement?.type === "submenu") {
@@ -25,7 +29,9 @@ export const closeSubMenu = (
   meta: SlashMenuMeta,
   initialState: SlashMenuState
 ) => {
-  const menuElement = meta.element;
+  const menuElement = meta.element as SubMenu;
+  const callback = menuElement.callbackOnClose;
+  callback && callback();
   if (menuElement?.type === "submenu") {
     const parentId = findParent(menuElement.id, initialState.filteredElements);
     if (parentId === "root") {
@@ -56,17 +62,4 @@ export const prevItem = (state: SlashMenuState) => {
 };
 export const filterItems = (state: SlashMenuState, filter: string) => {
   return { ...state, filter };
-};
-export const updateInput = (
-  state: SlashMenuState,
-  meta: SlashMenuMeta,
-  initialState: SlashMenuState
-) => {
-  return {
-    ...state,
-    filteredElements: meta.filter
-      ? getFilteredItems(initialState, meta.filter)
-      : initialState.elements,
-    filter: meta.filter || "",
-  };
 };

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6,7 +6,6 @@ import {
 } from "./utils";
 import { SlashMenuMeta, SlashMenuState, SubMenu } from "./types";
 export const closeMenu = (initialState: SlashMenuState) => {
-  console.log("closingMenu");
   const callback = initialState.callbackOnClose;
   callback && callback();
   return initialState;
@@ -16,6 +15,7 @@ export const openSubMenu = (state: SlashMenuState, meta: SlashMenuMeta) => {
   if (menuElement?.type === "submenu") {
     return {
       ...state,
+      open: true,
       filteredElements: menuElement.elements,
       selected: menuElement.elements[0].id,
       subMenuId: menuElement.id,

--- a/src/cases.ts
+++ b/src/cases.ts
@@ -96,7 +96,6 @@ export const getCase = (
     if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
       return SlashCases.Catch;
     }
-    console.log("here");
   }
 
   return SlashCases.Ignore;

--- a/src/cases.ts
+++ b/src/cases.ts
@@ -14,51 +14,61 @@ export enum SlashCases {
   Ignore = "Ignore",
   Catch = "Catch",
 }
-const defaultConditions: OpeningConditions = {
-  shouldOpen: (
-    state: SlashMenuState,
-    event: KeyboardEvent,
-    view: EditorView
-  ) => {
-    const editorState = view.state;
-    const resolvedPos =
-      editorState.selection.from < 0 ||
-      editorState.selection.from > editorState.doc.content.size
-        ? null
-        : editorState.doc.resolve(editorState.selection.from);
+const defaultConditions = (
+  openInSelection: boolean = false
+): OpeningConditions => {
+  return {
+    shouldOpen: (
+      state: SlashMenuState,
+      event: KeyboardEvent,
+      view: EditorView
+    ) => {
+      const editorState = view.state;
+      const resolvedPos =
+        editorState.selection.from < 0 ||
+        editorState.selection.from > editorState.doc.content.size
+          ? null
+          : editorState.doc.resolve(editorState.selection.from);
 
-    const parentNode = resolvedPos?.parent;
-    const inParagraph = parentNode?.type.name === "paragraph";
-    const inEmptyPar = inParagraph && parentNode?.nodeSize === 2;
-    const posInLine = editorState.selection.$head.parentOffset;
-    const prevCharacter = editorState.selection.$head.parent.textContent.slice(
-      posInLine - 1,
-      posInLine
-    );
-    const spaceBeforePos =
-      prevCharacter === " " || prevCharacter === "" || prevCharacter === " ";
-    return (
-      !state.open &&
-      event.key === "/" &&
-      inParagraph &&
-      (inEmptyPar || spaceBeforePos)
-    );
-  },
-  shouldClose: (state: SlashMenuState, event: KeyboardEvent) =>
-    state.open &&
-    (event.key === "/" ||
-      event.key === "Escape" ||
-      event.key === "Backspace") &&
-    state.filter.length === 0,
+      const parentNode = resolvedPos?.parent;
+      const inParagraph = parentNode?.type.name === "paragraph";
+      const inEmptyPar = inParagraph && parentNode?.nodeSize === 2;
+      const posInLine = editorState.selection.$head.parentOffset;
+      const prevCharacter =
+        editorState.selection.$head.parent.textContent.slice(
+          posInLine - 1,
+          posInLine
+        );
+      const spaceBeforePos =
+        prevCharacter === " " || prevCharacter === "" || prevCharacter === " ";
+      return (
+        !state.open &&
+        event.key === "/" &&
+        inParagraph &&
+        (inEmptyPar ||
+          spaceBeforePos ||
+          (editorState.selection.from !== editorState.selection.to &&
+            openInSelection))
+      );
+    },
+    shouldClose: (state: SlashMenuState, event: KeyboardEvent) =>
+      state.open &&
+      (event.key === "/" ||
+        event.key === "Escape" ||
+        event.key === "Backspace") &&
+      state.filter.length === 0,
+  };
 };
 export const getCase = (
   state: SlashMenuState,
   event: KeyboardEvent,
   view: EditorView,
   ignoredKeys: string[],
-  customConditions?: OpeningConditions
+  customConditions?: OpeningConditions,
+  shouldOpenInSelection?: boolean
 ): SlashCases => {
-  const condition = customConditions || defaultConditions;
+  const condition =
+    customConditions || defaultConditions(shouldOpenInSelection);
   const selected = getElementById(state.selected, state);
   if (condition.shouldOpen(state, event, view)) {
     return SlashCases.OpenMenu;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import {
   ItemType,
 } from "./types";
 import { SlashMetaTypes } from "./enums";
-import { openSubMenu } from "./actions";
 
 export {
   SlashMenuPlugin,
@@ -28,5 +27,4 @@ export {
   ItemId,
   CommandItem,
   ItemType,
-  openSubMenu,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   ItemType,
 } from "./types";
 import { SlashMetaTypes } from "./enums";
+import { openSubMenu } from "./actions";
 
 export {
   SlashMenuPlugin,
@@ -27,4 +28,5 @@ export {
   ItemId,
   CommandItem,
   ItemType,
+  openSubMenu,
 };

--- a/src/keyHandlers.ts
+++ b/src/keyHandlers.ts
@@ -8,10 +8,10 @@ const execute = (view: EditorView, state: SlashMenuState) => {
   const menuElement = getElementById(state.selected, state);
   if (!menuElement) return false;
   if (menuElement.type === "command") {
-    menuElement.command(view);
     dispatchWithMeta(view, SlashMenuKey, {
       type: SlashMetaTypes.execute,
     });
+    menuElement.command(view);
   }
   if (menuElement.type === "submenu") {
     dispatchWithMeta(view, SlashMenuKey, {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,7 +27,8 @@ export const SlashMenuKey = new PluginKey<SlashMenuState>("slash-menu-plugin");
 export const SlashMenuPlugin = (
   menuElements: MenuElement[],
   ignoredKeys?: string[],
-  customConditions?: OpeningConditions
+  customConditions?: OpeningConditions,
+  openInSelection?: boolean
 ) => {
   const initialState: SlashMenuState = {
     selected: menuElements[0].id,
@@ -36,7 +37,7 @@ export const SlashMenuPlugin = (
     ignoredKeys: ignoredKeys
       ? [...defaultIgnoredKeys, ...ignoredKeys]
       : defaultIgnoredKeys,
-    filteredElements: menuElements,
+    filteredElements: menuElements.filter((element) => !element.locked),
     elements: menuElements,
   };
   if (hasDuplicateIds(initialState)) {
@@ -54,7 +55,8 @@ export const SlashMenuPlugin = (
           event,
           view,
           initialState.ignoredKeys,
-          customConditions
+          customConditions,
+          openInSelection
         );
         switch (slashCase) {
           case SlashCases.OpenMenu:
@@ -96,10 +98,10 @@ export const SlashMenuPlugin = (
             const menuElement = getElementById(state.selected, state);
             if (!menuElement) return false;
             if (menuElement.type === "command") {
-              menuElement.command(view);
               dispatchWithMeta(view, SlashMenuKey, {
                 type: SlashMetaTypes.execute,
               });
+              menuElement.command(view);
             }
             if (menuElement.type === "submenu") {
               dispatchWithMeta(view, SlashMenuKey, {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -69,7 +69,6 @@ export const SlashMenuPlugin = (
                 initialState
               ) as SubMenu;
               const callback = submenu?.callbackOnClose;
-              console.log("locked", submenu?.locked);
               if (!submenu?.locked) {
                 callback && callback();
                 dispatchWithMeta(view, SlashMenuKey, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type MenuElement = CommandItem | SubMenu;
 export interface SubMenu extends MenuItem {
   type: "submenu";
   elements: MenuElement[];
+  callbackOnClose?: () => void;
 }
 
 export type SlashMenuState = {
@@ -32,6 +33,7 @@ export type SlashMenuState = {
   filter: string;
   elements: MenuElement[];
   ignoredKeys: string[];
+  callbackOnClose?: () => void;
 };
 
 export interface SlashMenuMeta {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type MenuItem = {
   label: string;
   type: ItemType;
   available: (view: EditorView) => boolean;
+  hidden?: boolean;
 };
 
 export interface CommandItem extends MenuItem {
@@ -23,6 +24,7 @@ export interface SubMenu extends MenuItem {
   type: "submenu";
   elements: MenuElement[];
   callbackOnClose?: () => void;
+  locked?: boolean;
 }
 
 export type SlashMenuState = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type MenuItem = {
   label: string;
   type: ItemType;
   available: (view: EditorView) => boolean;
-  hidden?: boolean;
+  locked?: boolean;
 };
 
 export interface CommandItem extends MenuItem {
@@ -24,7 +24,6 @@ export interface SubMenu extends MenuItem {
   type: "submenu";
   elements: MenuElement[];
   callbackOnClose?: () => void;
-  locked?: boolean;
 }
 
 export type SlashMenuState = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,12 @@
 import { EditorView } from "prosemirror-view";
 import { PluginKey } from "prosemirror-state";
-import { ItemId, MenuElement, SlashMenuMeta, SlashMenuState } from "./types";
+import {
+  ItemId,
+  MenuElement,
+  SlashMenuMeta,
+  SlashMenuState,
+  SubMenu,
+} from "./types";
 
 export const getElementIds = (item: MenuElement): ItemId[] => {
   if (item.type === "submenu")
@@ -97,13 +103,15 @@ export const dispatchWithMeta = (
 
 export const getFilteredItems = (state: SlashMenuState, input: string) => {
   const regExp = new RegExp(`${input.toLowerCase().replace(/\s/g, "\\s")}`);
-  return getAllElements(state)
-    .map((el) => el)
-    .filter(
-      (element) =>
-        element.label.toLowerCase().match(regExp) !== null &&
-        element.type !== "submenu"
+  if (state.subMenuId && state.subMenuId !== "root") {
+    const submenu = getElementById(state.subMenuId, state) as SubMenu;
+    return submenu.elements.filter(
+      (element) => element.label.toLowerCase().match(regExp) !== null
     );
+  }
+  return state.elements.filter(
+    (element) => element.label.toLowerCase().match(regExp) !== null
+  );
 };
 
 export const defaultIgnoredKeys = [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,7 +110,8 @@ export const getFilteredItems = (state: SlashMenuState, input: string) => {
     );
   }
   return state.elements.filter(
-    (element) => element.label.toLowerCase().match(regExp) !== null
+    (element) =>
+      element.label.toLowerCase().match(regExp) !== null && !element.locked
   );
 };
 


### PR DESCRIPTION
Added option for the menu to have locked menu items that are hidden by default, can be used for submenus that are manually opened through custom code.
Added prop to allow the menu to open even if there is a selection. 